### PR TITLE
Update for PureScript 0.7 and Common Isomorphisms

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,5 +9,10 @@
     "node_modules",
     "bower_components",
     "output"
-  ]
+  ],
+  "devDependencies": {
+    "purescript-spec": "~0.7.1",
+    "purescript-spec-quickcheck": "~0.3.0",
+    "purescript-quickcheck": "~0.7.0"
+  }
 }

--- a/docs/Data/Iso.md
+++ b/docs/Data/Iso.md
@@ -48,8 +48,10 @@ Isomorphism is symmetric
 #### `prodIdent`
 
 ``` purescript
-prodIdent :: forall a. Iso a (Tuple Unit a)
+prodIdent :: forall a. Iso (Tuple Unit a) a
 ```
+
+$1 \times a = a$
 
 #### `prodAssoc`
 
@@ -57,11 +59,15 @@ prodIdent :: forall a. Iso a (Tuple Unit a)
 prodAssoc :: forall a b c. Iso (Tuple a (Tuple b c)) (Tuple (Tuple a b) c)
 ```
 
+$a \times (b \times c) = (a \times b) \times c$ 
+
 #### `prodComm`
 
 ``` purescript
 prodComm :: forall a b. Iso (Tuple a b) (Tuple b a)
 ```
+
+$a \times b = b \times a$
 
 #### `prodZeroZero`
 
@@ -69,11 +75,15 @@ prodComm :: forall a b. Iso (Tuple a b) (Tuple b a)
 prodZeroZero :: forall a b. Iso (Tuple Void a) Void
 ```
 
+$0 \times a = 0$
+
 #### `coprodIdent`
 
 ``` purescript
-coprodIdent :: forall a. Iso a (Either Void a)
+coprodIdent :: forall a. Iso (Either Void a) a
 ```
+
+$0 + a = a$
 
 #### `coprodAssoc`
 
@@ -81,11 +91,15 @@ coprodIdent :: forall a. Iso a (Either Void a)
 coprodAssoc :: forall a b c. Iso (Either a (Either b c)) (Either (Either a b) c)
 ```
 
+$a + (b + c) = (a + b) + c$
+
 #### `coprodComm`
 
 ``` purescript
 coprodComm :: forall a b. Iso (Either a b) (Either b a)
 ```
+
+$a + b = b + a$
 
 #### `distribute`
 
@@ -93,11 +107,15 @@ coprodComm :: forall a b. Iso (Either a b) (Either b a)
 distribute :: forall a b c. Iso (Tuple a (Either b c)) (Either (Tuple a b) (Tuple a c))
 ```
 
+$a \times (b + c) = (a \times b) + (a \times c)$
+
 #### `onePlusMaybe`
 
 ``` purescript
 onePlusMaybe :: forall a. Iso (Either Unit a) (Maybe a)
 ```
+
+$1 + a = `Maybe` a$
 
 #### `onePlusOneIsTwo`
 
@@ -105,11 +123,15 @@ onePlusMaybe :: forall a. Iso (Either Unit a) (Maybe a)
 onePlusOneIsTwo :: forall a. Iso (Either Unit Unit) Boolean
 ```
 
+$1 + 1 = 2$
+
 #### `expProdSum`
 
 ``` purescript
 expProdSum :: forall a b c. Iso (Tuple (b -> a) (c -> a)) (Either b c -> a)
 ```
+
+$a^b \times a^c = a^{b + c}$
 
 #### `expExpProd`
 
@@ -117,11 +139,15 @@ expProdSum :: forall a b c. Iso (Tuple (b -> a) (c -> a)) (Either b c -> a)
 expExpProd :: forall a b c. Iso (Tuple a b -> c) (a -> b -> c)
 ```
 
+$c^{a \times b} = (c^{b})^{a}$
+
 #### `expOne`
 
 ``` purescript
 expOne :: forall a. Iso (Unit -> a) a
 ```
+
+$a^1 = a$
 
 #### `expZero`
 
@@ -129,11 +155,15 @@ expOne :: forall a. Iso (Unit -> a) a
 expZero :: forall a. Iso (Void -> a) Unit
 ```
 
+$a^0 = 1$
+
 #### `functorCong`
 
 ``` purescript
 functorCong :: forall a b f. (Functor f) => Iso a b -> Iso (f a) (f b)
 ```
+
+$a = b \implies f(a) = f(b)$
 
 #### `bifunctorCongLeft`
 
@@ -141,16 +171,22 @@ functorCong :: forall a b f. (Functor f) => Iso a b -> Iso (f a) (f b)
 bifunctorCongLeft :: forall a a' b f. (Bifunctor f) => Iso a a' -> Iso (f a b) (f a' b)
 ```
 
+$a = a\prime \implies f(a, b) = f(a\prime, b)$
+
 #### `contraCong`
 
 ``` purescript
 contraCong :: forall a b c f. (Contravariant f) => Iso a b -> Iso (f a) (f b)
 ```
 
+$a = b \implies f(a) = f(b)$
+
 #### `profunctorCongLeft`
 
 ``` purescript
 profunctorCongLeft :: forall a a' b c f. (Profunctor f) => Iso a a' -> Iso (f a b) (f a' b)
 ```
+
+$a = a\prime \implies f(a, b) = f(a\prime, b)$
 
 

--- a/docs/Data/Iso.md
+++ b/docs/Data/Iso.md
@@ -1,0 +1,156 @@
+## Module Data.Iso
+
+#### `Iso`
+
+``` purescript
+data Iso a b
+  = Iso (a -> b) (b -> a)
+```
+
+An isomorphism between types `a` and `b` consists of a pair of functions 
+`f :: a -> b` and `g :: b -> a`, satisfying the following laws:
+
+- `f <<< g = id`
+- `g <<< f = id`
+
+The isomorphisms in this library satisfy these laws by construction.
+
+##### Instances
+``` purescript
+instance semigroupoidIso :: Semigroupoid Iso
+instance categoryIso :: Category Iso
+```
+
+#### `forwards`
+
+``` purescript
+forwards :: forall a b. Iso a b -> a -> b
+```
+
+Run an isomorphism "forwards".
+
+#### `backwards`
+
+``` purescript
+backwards :: forall a b. Iso a b -> b -> a
+```
+
+Run an isomorphism "backwards".
+
+#### `sym`
+
+``` purescript
+sym :: forall a b. Iso a b -> Iso b a
+```
+
+Isomorphism is symmetric
+
+#### `prodIdent`
+
+``` purescript
+prodIdent :: forall a. Iso a (Tuple Unit a)
+```
+
+#### `prodAssoc`
+
+``` purescript
+prodAssoc :: forall a b c. Iso (Tuple a (Tuple b c)) (Tuple (Tuple a b) c)
+```
+
+#### `prodComm`
+
+``` purescript
+prodComm :: forall a b. Iso (Tuple a b) (Tuple b a)
+```
+
+#### `prodZeroZero`
+
+``` purescript
+prodZeroZero :: forall a b. Iso (Tuple Void a) Void
+```
+
+#### `coprodIdent`
+
+``` purescript
+coprodIdent :: forall a. Iso a (Either Void a)
+```
+
+#### `coprodAssoc`
+
+``` purescript
+coprodAssoc :: forall a b c. Iso (Either a (Either b c)) (Either (Either a b) c)
+```
+
+#### `coprodComm`
+
+``` purescript
+coprodComm :: forall a b. Iso (Either a b) (Either b a)
+```
+
+#### `distribute`
+
+``` purescript
+distribute :: forall a b c. Iso (Tuple a (Either b c)) (Either (Tuple a b) (Tuple a c))
+```
+
+#### `onePlusMaybe`
+
+``` purescript
+onePlusMaybe :: forall a. Iso (Either Unit a) (Maybe a)
+```
+
+#### `onePlusOneIsTwo`
+
+``` purescript
+onePlusOneIsTwo :: forall a. Iso (Either Unit Unit) Boolean
+```
+
+#### `expProdSum`
+
+``` purescript
+expProdSum :: forall a b c. Iso (Tuple (b -> a) (c -> a)) (Either b c -> a)
+```
+
+#### `expExpProd`
+
+``` purescript
+expExpProd :: forall a b c. Iso (Tuple a b -> c) (a -> b -> c)
+```
+
+#### `expOne`
+
+``` purescript
+expOne :: forall a. Iso (Unit -> a) a
+```
+
+#### `expZero`
+
+``` purescript
+expZero :: forall a. Iso (Void -> a) Unit
+```
+
+#### `functorCong`
+
+``` purescript
+functorCong :: forall a b f. (Functor f) => Iso a b -> Iso (f a) (f b)
+```
+
+#### `bifunctorCongLeft`
+
+``` purescript
+bifunctorCongLeft :: forall a a' b f. (Bifunctor f) => Iso a a' -> Iso (f a b) (f a' b)
+```
+
+#### `contraCong`
+
+``` purescript
+contraCong :: forall a b c f. (Contravariant f) => Iso a b -> Iso (f a) (f b)
+```
+
+#### `profunctorCongLeft`
+
+``` purescript
+profunctorCongLeft :: forall a a' b c f. (Profunctor f) => Iso a a' -> Iso (f a b) (f a' b)
+```
+
+

--- a/src/Data/Iso.purs
+++ b/src/Data/Iso.purs
@@ -1,6 +1,16 @@
-module Data.Iso 
-  ( Iso(..)
-  ) where
+module Data.Iso where
+
+import Prelude
+
+import Data.Profunctor.Strong ((***), first, second)
+import Data.Profunctor.Choice (left, right)
+import qualified Data.Bifunctor as B
+import qualified Data.Profunctor as P
+import Data.Functor.Contravariant (Contravariant, cmap)
+import Data.Maybe (Maybe(..), maybe)
+import Data.Either (Either(..), either)
+import Data.Tuple (Tuple(..), swap, fst, snd, curry, uncurry)
+import Data.Void (Void(), absurd)
 
 -- | An isomorphism between types `a` and `b` consists of a pair of functions 
 -- | `f :: a -> b` and `g :: b -> a`, satisfying the following laws:
@@ -23,8 +33,77 @@ backwards (Iso _ f) = f
 sym :: forall a b. Iso a b -> Iso b a
 sym (Iso f g) = Iso g f
 
+prodIdent :: forall a. Iso a (Tuple Unit a)
+prodIdent = Iso (Tuple unit) snd
+
+prodAssoc :: forall a b c. Iso (Tuple a (Tuple b c)) (Tuple (Tuple a b) c)
+prodAssoc = Iso to from
+  where to   (Tuple a (Tuple b c)) = Tuple (Tuple a b) c
+        from (Tuple (Tuple a b) c) = Tuple a (Tuple b c)
+
+prodComm :: forall a b. Iso (Tuple a b) (Tuple b a)
+prodComm = Iso swap swap
+
+prodZeroZero :: forall a b. Iso (Tuple Void a) Void
+prodZeroZero = Iso fst absurd
+
+coprodIdent :: forall a. Iso a (Either Void a)
+coprodIdent = Iso Right (either absurd id)
+
+coprodAssoc :: forall a b c. Iso (Either a (Either b c)) (Either (Either a b) c)
+coprodAssoc = Iso to from
+  where to   (Left a)          = Left (Left a)
+        to   (Right (Left b))  = Left (Right b)
+        to   (Right (Right c)) = Right c
+        from (Left (Left a))   = Left a
+        from (Left (Right b))  = Right (Left b)
+        from (Right c)         = Right (Right c)
+
+coprodComm :: forall a b. Iso (Either a b) (Either b a)
+coprodComm = Iso (either Right Left) (either Right Left)
+
+distribute :: forall a b c. Iso (Tuple a (Either b c)) (Either (Tuple a b) (Tuple a c))
+distribute = Iso to from
+  where to (Tuple a e) = B.bimap (Tuple a) (Tuple a) e
+        from (Left  t) = map Left t
+        from (Right t) = map Right t
+
+onePlusMaybe :: forall a. Iso (Either Unit a) (Maybe a)
+onePlusMaybe = Iso (either (const Nothing) Just) (maybe (Left unit) Right)
+
+onePlusOneIsTwo :: forall a. Iso (Either Unit Unit) Boolean
+onePlusOneIsTwo = Iso to from
+  where to = either (const false) (const true)
+        from b = if b then Right unit else Left unit
+
+expProdSum :: forall a b c. Iso (Tuple (b -> a) (c -> a)) (Either b c -> a)
+expProdSum = Iso to from
+  where to = uncurry either
+        from f = Tuple (f <<< Left) (f <<< Right)
+
+expExpProd :: forall a b c. Iso (Tuple a b -> c) (a -> b -> c)
+expExpProd = Iso curry uncurry
+
+expOne :: forall a. Iso (Unit -> a) a
+expOne = Iso ($ unit) const
+
+expZero :: forall a. Iso (Void -> a) Unit
+expZero = Iso (const unit) (const absurd)
+
+functorCong :: forall a b f. (Functor f) => Iso a b -> Iso (f a) (f b)
+functorCong (Iso f g) = Iso (map f) (map g)
+
+bifunctorCongLeft :: forall a a' b f. (B.Bifunctor f) => Iso a a' -> Iso (f a b) (f a' b)
+bifunctorCongLeft (Iso f g) = Iso (B.lmap f) (B.lmap g)
+
+contraCong :: forall a b c f. (Contravariant f) => Iso a b -> Iso (f a) (f b)
+contraCong (Iso f g) = Iso (cmap g) (cmap f)
+
+profunctorCongLeft :: forall a a' b c f. (P.Profunctor f) => Iso a a' -> Iso (f a b) (f a' b)
+profunctorCongLeft (Iso f g) = Iso (P.lmap g) (P.lmap f)
+
 instance semigroupoidIso :: Semigroupoid Iso where
-  (<<<) (Iso f1 g1) (Iso f2 g2) = Iso (f1 <<< f2) (g1 >>> g2)
+  compose (Iso f1 g1) (Iso f2 g2) = Iso (f1 <<< f2) (g1 >>> g2)
 
 instance categoryIso :: Category Iso where
   id = Iso id id

--- a/src/Data/Iso.purs
+++ b/src/Data/Iso.purs
@@ -33,23 +33,29 @@ backwards (Iso _ f) = f
 sym :: forall a b. Iso a b -> Iso b a
 sym (Iso f g) = Iso g f
 
-prodIdent :: forall a. Iso a (Tuple Unit a)
-prodIdent = Iso (Tuple unit) snd
+-- | $1 \times a = a$
+prodIdent :: forall a. Iso (Tuple Unit a) a
+prodIdent = Iso snd (Tuple unit)
 
+-- | $a \times (b \times c) = (a \times b) \times c$ 
 prodAssoc :: forall a b c. Iso (Tuple a (Tuple b c)) (Tuple (Tuple a b) c)
 prodAssoc = Iso to from
   where to   (Tuple a (Tuple b c)) = Tuple (Tuple a b) c
         from (Tuple (Tuple a b) c) = Tuple a (Tuple b c)
 
+-- | $a \times b = b \times a$
 prodComm :: forall a b. Iso (Tuple a b) (Tuple b a)
 prodComm = Iso swap swap
 
+-- | $0 \times a = 0$
 prodZeroZero :: forall a b. Iso (Tuple Void a) Void
 prodZeroZero = Iso fst absurd
 
-coprodIdent :: forall a. Iso a (Either Void a)
-coprodIdent = Iso Right (either absurd id)
+-- | $0 + a = a$
+coprodIdent :: forall a. Iso (Either Void a) a
+coprodIdent = Iso (either absurd id) Right
 
+-- | $a + (b + c) = (a + b) + c$
 coprodAssoc :: forall a b c. Iso (Either a (Either b c)) (Either (Either a b) c)
 coprodAssoc = Iso to from
   where to   (Left a)          = Left (Left a)
@@ -59,51 +65,65 @@ coprodAssoc = Iso to from
         from (Left (Right b))  = Right (Left b)
         from (Right c)         = Right (Right c)
 
+-- | $a + b = b + a$
 coprodComm :: forall a b. Iso (Either a b) (Either b a)
 coprodComm = Iso (either Right Left) (either Right Left)
 
+-- | $a \times (b + c) = (a \times b) + (a \times c)$
 distribute :: forall a b c. Iso (Tuple a (Either b c)) (Either (Tuple a b) (Tuple a c))
 distribute = Iso to from
   where to (Tuple a e) = B.bimap (Tuple a) (Tuple a) e
         from (Left  t) = map Left t
         from (Right t) = map Right t
 
+-- | $1 + a = `Maybe` a$
 onePlusMaybe :: forall a. Iso (Either Unit a) (Maybe a)
 onePlusMaybe = Iso (either (const Nothing) Just) (maybe (Left unit) Right)
 
+-- | $1 + 1 = 2$
 onePlusOneIsTwo :: forall a. Iso (Either Unit Unit) Boolean
 onePlusOneIsTwo = Iso to from
   where to = either (const false) (const true)
         from b = if b then Right unit else Left unit
 
+-- | $a^b \times a^c = a^{b + c}$
 expProdSum :: forall a b c. Iso (Tuple (b -> a) (c -> a)) (Either b c -> a)
 expProdSum = Iso to from
   where to = uncurry either
         from f = Tuple (f <<< Left) (f <<< Right)
 
+-- | $c^{a \times b} = (c^{b})^{a}$
 expExpProd :: forall a b c. Iso (Tuple a b -> c) (a -> b -> c)
 expExpProd = Iso curry uncurry
 
+-- | $a^1 = a$
 expOne :: forall a. Iso (Unit -> a) a
 expOne = Iso ($ unit) const
 
+-- | $a^0 = 1$
 expZero :: forall a. Iso (Void -> a) Unit
 expZero = Iso (const unit) (const absurd)
 
+-- | $a = b \implies f(a) = f(b)$
 functorCong :: forall a b f. (Functor f) => Iso a b -> Iso (f a) (f b)
 functorCong (Iso f g) = Iso (map f) (map g)
 
+-- | $a = a\prime \implies f(a, b) = f(a\prime, b)$
 bifunctorCongLeft :: forall a a' b f. (B.Bifunctor f) => Iso a a' -> Iso (f a b) (f a' b)
 bifunctorCongLeft (Iso f g) = Iso (B.lmap f) (B.lmap g)
 
+-- | $a = b \implies f(a) = f(b)$
 contraCong :: forall a b c f. (Contravariant f) => Iso a b -> Iso (f a) (f b)
 contraCong (Iso f g) = Iso (cmap g) (cmap f)
 
+-- | $a = a\prime \implies f(a, b) = f(a\prime, b)$
 profunctorCongLeft :: forall a a' b c f. (P.Profunctor f) => Iso a a' -> Iso (f a b) (f a' b)
 profunctorCongLeft (Iso f g) = Iso (P.lmap g) (P.lmap f)
 
+-- | $b = c \wedge a = b \implies a = c$
 instance semigroupoidIso :: Semigroupoid Iso where
   compose (Iso f1 g1) (Iso f2 g2) = Iso (f1 <<< f2) (g1 >>> g2)
 
+-- | $a = a$
 instance categoryIso :: Category Iso where
   id = Iso id id

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,74 @@
+module Test.Main where
+
+import Prelude
+
+import Control.Monad.Aff          (Aff())
+import Control.Monad.Eff.Random   (RANDOM())
+import Data.Either                (Either())
+import Data.Maybe                 (Maybe())
+import Data.Tuple                 (Tuple())
+import Test.Spec                  (Spec(), describe, it)
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.Runner           (run)
+import Test.Spec.QuickCheck       (quickCheck)
+import Test.QuickCheck            (Result(), (===))
+import Test.QuickCheck.Arbitrary  (Arbitrary)
+
+import Data.Iso
+
+type A = Int
+type B = String
+type C = Boolean
+
+-- Most of the isomorphisms should have fairly strong parametric guarantees
+main = run [consoleReporter] do
+  describe "Data.Iso" do
+    describe "id" do
+      testIso (id :: Iso A A)
+    {- compose
+     - sym
+     -}
+    describe "prodIdent" do
+      testIso (prodIdent :: Iso A (Tuple Unit A))
+    describe "prodAssoc" do
+      testIso (prodAssoc :: Iso (Tuple A (Tuple B C)) (Tuple (Tuple A B) C))
+    describe "prodComm" do
+      testIso (prodComm :: Iso (Tuple A B) (Tuple B A))
+    {- prodZeroZero
+     - coprodIdent
+     -}
+    describe "coprodAssoc" do
+      testIso (coprodAssoc :: Iso (Either A (Either B C)) (Either (Either A B) C))
+    describe "coprodComm" do
+      testIso (coprodComm :: Iso (Either A B) (Either B A))
+    describe "distribute" do
+      testIso (distribute :: Iso (Tuple A (Either B C)) (Either (Tuple A B) (Tuple A C)))
+    describe "onePlusMaybe" do
+      testIso (onePlusMaybe :: Iso (Either Unit A) (Maybe A))
+    describe "onePlusOneIsTwo" do
+      testIso (onePlusOneIsTwo :: Iso (Either Unit Unit) Boolean)
+    {- expProdSum
+     - expOne
+     - expZero
+     - functorCong
+     - bifunctorCongLeft
+     - contraCong
+     - profunctorCongLeft
+     -}
+
+
+testIso :: forall a b r.
+           (Arbitrary a, Arbitrary b, Eq a, Eq b, Show a, Show b)
+        => Iso a b
+        -> Spec (random :: RANDOM | r) Unit
+testIso iso = do
+  it "has `backward <<< forward` as the identity" do
+    isId (backwards iso <<< forwards iso)
+  it "has `forward <<< backward` as the identity" do
+    isId (forwards iso <<< backwards iso)
+
+isId :: forall a r.
+        (Arbitrary a, Eq a, Show a)
+     => (a -> a)
+     -> Aff (random :: RANDOM | r) Unit
+isId f = quickCheck \x -> f x === x

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -29,7 +29,7 @@ main = run [consoleReporter] do
      - sym
      -}
     describe "prodIdent" do
-      testIso (prodIdent :: Iso A (Tuple Unit A))
+      testIso (prodIdent :: Iso (Tuple Unit A) A)
     describe "prodAssoc" do
       testIso (prodAssoc :: Iso (Tuple A (Tuple B C)) (Tuple (Tuple A B) C))
     describe "prodComm" do


### PR DESCRIPTION
The only change needed for 0.7 was replacing `(<<<)` with `compose` in the `Semigroupoid` instance. The isomorphisms are mostly arithmetic laws. The naming for the isomorphisms is fairly ad hoc, though I generally aimed to name them after the law they demonstrate. I have seen [Idris](http://www.idris-lang.org/docs/base_doc/docs/Control.Isomorphism.html) name them similarly, but using the actual constructor names (e.g. `Void` vs `Zero`).
